### PR TITLE
Add Tenderly simulation support

### DIFF
--- a/src/chrome/inject.ts
+++ b/src/chrome/inject.ts
@@ -1,4 +1,4 @@
-import { NetworksInfo } from "../types";
+import { NetworksInfo, SimulationInfo } from "../types";
 
 let store = {
   address: "",
@@ -36,6 +36,9 @@ const init = async () => {
       const { networksInfo } = (await chrome.storage.sync.get(
         "networksInfo"
       )) as { networksInfo: NetworksInfo | undefined };
+      const { simulationInfo } = (await chrome.storage.sync.get(
+        "simulationInfo"
+      )) as { simulationInfo: SimulationInfo | undefined };
 
       if (
         networksInfo &&
@@ -57,6 +60,7 @@ const init = async () => {
               address,
               chainId: networksInfo[chainName].chainId,
               rpcUrl: networksInfo[chainName].rpcUrl,
+              simulationInfo
             },
           },
           "*"

--- a/src/components/Settings/Chains.tsx
+++ b/src/components/Settings/Chains.tsx
@@ -14,6 +14,7 @@ import { useNetworks } from "@/contexts/NetworksContext";
 import { NetworksInfo } from "@/types";
 import AddChain from "./AddChain";
 import EditChain from "./EditChain";
+import EditSimulation from "./EditSimulation";
 
 function Chain({
   chainName,
@@ -89,6 +90,9 @@ function Chains({ close }: { close: () => void }) {
             onClick={() => setTab(<AddChain back={() => setTab(undefined)} />)}
           >
             Add Chain
+          </Button>
+          <Button onClick={() => setTab(<EditSimulation back={() => setTab(undefined)} />)}>
+            Edit Simulation Settings
           </Button>
         </Stack>
       </Center>

--- a/src/components/Settings/EditSimulation.tsx
+++ b/src/components/Settings/EditSimulation.tsx
@@ -41,6 +41,12 @@ function EditSimulation({ back }: { back: () => void }) {
     setIsBtnLoading(false);
   };
 
+  const deleteSettings = () => {
+    setReloadRequired(true);
+    setSimulationInfo(undefined);
+    back();
+  }
+
   useEffect(() => {
     if (simulationInfo) {
       setProjectSlug(simulationInfo.projectSlug);
@@ -101,16 +107,29 @@ function EditSimulation({ back }: { back: () => void }) {
             }}
             isInvalid={!accessKey}
           />
-          <Center>
-            <Button
-              onClick={() => saveSettings()}
-              isLoading={isBtnLoading}
-              disabled={
-                !accountSlug || !projectSlug || !accessKey || isBtnLoading
-              }
-            >
-              Save Simulation Settings
-            </Button>
+                    <Center>
+            <HStack spacing="3">
+              <Button
+                size="sm"
+                maxW="6rem"
+                colorScheme="blue"
+                onClick={() => saveSettings()}
+                isLoading={isBtnLoading}
+                disabled={
+                  !accountSlug || !projectSlug || !accessKey || isBtnLoading
+                }
+              >
+                Save
+              </Button>
+              <Button
+                size="sm"
+                maxW="6rem"
+                colorScheme="red"
+                onClick={() => deleteSettings()}
+              >
+                Delete
+              </Button>
+            </HStack>
           </Center>
         </Stack>
       </Box>

--- a/src/components/Settings/EditSimulation.tsx
+++ b/src/components/Settings/EditSimulation.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Center,
+  Box,
+  Input,
+  Heading,
+  Stack,
+  Flex,
+  Spacer,
+  HStack,
+  Text,
+} from "@chakra-ui/react";
+import { ChevronLeftIcon } from "@chakra-ui/icons";
+import { useSimulation } from "@/contexts/SimulationContext";
+import { useNetworks } from "@/contexts/NetworksContext";
+
+function EditSimulation({ back }: { back: () => void }) {
+  const { simulationInfo, setSimulationInfo } = useSimulation();
+  const { setReloadRequired } = useNetworks();
+
+  const [accountSlug, setAccountSlug] = useState<string>("");
+  const [projectSlug, setProjectSlug] = useState<string>("");
+  const [accessKey, setAccessKey] = useState<string>("");
+  const [isBtnLoading, setIsBtnLoading] = useState(false);
+
+  const saveSettings = () => {
+    setIsBtnLoading(true);
+
+    setReloadRequired(true);
+    setSimulationInfo(simulationInfo => {
+      return {
+        ...simulationInfo,
+        accountSlug,
+        projectSlug,
+        accessKey,
+      };
+    });
+    back();
+
+    setIsBtnLoading(false);
+  };
+
+  useEffect(() => {
+    if (simulationInfo) {
+      setProjectSlug(simulationInfo.projectSlug);
+      setAccountSlug(simulationInfo.accountSlug);
+      setAccessKey(simulationInfo.accessKey);
+    }
+  }, [simulationInfo]);
+
+  return (
+    <>
+      <Flex>
+        <Spacer />
+        <Button size="sm" variant="ghost" onClick={() => back()}>
+          <HStack>
+            <ChevronLeftIcon fontSize="2xl" /> <Text>Back</Text>
+          </HStack>
+        </Button>
+      </Flex>
+      <Box paddingBottom="0.5rem">
+        <Heading size="md">Simulation Settings</Heading>
+        <Stack mt="1rem" spacing={2}>
+          <Input
+            placeholder="Account Slug"
+            aria-label="Account Slug"
+            autoComplete="off"
+            minW="20rem"
+            size="sm"
+            rounded="lg"
+            value={accountSlug}
+            onChange={(e) => {
+              setAccountSlug(e.target.value);
+            }}
+            isInvalid={!accountSlug}
+          />
+          <Input
+            placeholder="Project Slug"
+            aria-label="Project Slug"
+            autoComplete="off"
+            minW="20rem"
+            size="sm"
+            rounded="lg"
+            value={projectSlug}
+            onChange={(e) => {
+              setProjectSlug(e.target.value);
+            }}
+            isInvalid={!projectSlug}
+          />
+          <Input
+            placeholder="Access Key"
+            aria-label="Access Key"
+            autoComplete="off"
+            minW="20rem"
+            size="sm"
+            rounded="lg"
+            value={accessKey}
+            onChange={(e) => {
+              setAccessKey(e.target.value);
+            }}
+            isInvalid={!accessKey}
+          />
+          <Center>
+            <Button
+              onClick={() => saveSettings()}
+              isLoading={isBtnLoading}
+              disabled={
+                !accountSlug || !projectSlug || !accessKey || isBtnLoading
+              }
+            >
+              Save Simulation Settings
+            </Button>
+          </Center>
+        </Stack>
+      </Box>
+    </>
+  );
+}
+
+export default EditSimulation;

--- a/src/contexts/SimulationContext.tsx
+++ b/src/contexts/SimulationContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useState, useEffect, useContext } from "react";
+import { useUpdateEffect } from "@chakra-ui/react";
+import { SimulationInfo } from "@/types";
+
+type SimulationContextType = {
+  simulationInfo: SimulationInfo | undefined;
+  setSimulationInfo: React.Dispatch<
+    React.SetStateAction<SimulationInfo | undefined>
+  >;
+};
+
+export const SimulationContext = createContext<SimulationContextType>({
+  simulationInfo: undefined,
+  setSimulationInfo: () => {},
+});
+
+export const SimulationProvider: React.FunctionComponent<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [simulationInfo, setSimulationInfo] = useState<SimulationInfo>();
+
+  useEffect(() => {
+    const fetch = async () => {
+      const { simulationInfo: storedSimulationInfo } =
+        (await chrome.storage.sync.get("simulationInfo")) as {
+          simulationInfo: SimulationInfo | undefined;
+        };
+
+      if (storedSimulationInfo) {
+        setSimulationInfo(storedSimulationInfo);
+      }
+    };
+
+    fetch();
+  }, []);
+
+  useUpdateEffect(() => {
+    const saveToBrowser = async () => {
+      await chrome.storage.sync.set({
+        simulationInfo,
+      });
+    };
+
+    saveToBrowser();
+  }, [simulationInfo]);
+
+  return (
+    <SimulationContext.Provider
+      value={{
+        simulationInfo,
+        setSimulationInfo,
+      }}
+    >
+      {children}
+    </SimulationContext.Provider>
+  );
+};
+
+export const useSimulation = () => useContext(SimulationContext);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,11 +5,14 @@ import { ChakraProvider } from "@chakra-ui/react";
 import theme from "./theme";
 import "./index.css";
 import { NetworksProvider } from "@/contexts/NetworksContext";
+import { SimulationProvider } from "./contexts/SimulationContext";
 
 ReactDOM.render(
   <ChakraProvider theme={theme}>
     <NetworksProvider>
-      <App />
+      <SimulationProvider>
+        <App />
+      </SimulationProvider>
     </NetworksProvider>
   </ChakraProvider>,
   document.getElementById("root")

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
 export type NetworksInfo = {
   [name: string]: { chainId: number; rpcUrl: string };
 };
+
+export type SimulationInfo = {
+  accountSlug: string;
+  projectSlug: string;
+  accessKey: string;
+}


### PR DESCRIPTION
Added tenderly simulation support, if a simulation account name, project slug & access key are available.
When the provider receives eth_sendTransaction it simulates the transaction on Tenderly & opens the simulation in a new tab once complete.

I made the choice to not return transactionHash for eth_sendTransaction, instead letting it silently fail by prompting the original RPC provider:
```ts
          // const txHash = json.transaction.hash;

          const link = this.getSimulationTxLink(id);
          window.open(link, "_blank");

          // return txHash;
          // Could return txHash, but most dApps will just end up cycling eth_getTransactionHash. Its not useful to return it.
```
But if someone finds a useful case for this, feel free to change it.